### PR TITLE
Add legends and subsystem diagrams for LArSoft workflow

### DIFF
--- a/activity.puml
+++ b/activity.puml
@@ -1,13 +1,28 @@
 @startuml LArSoft_Activity
+title LArSoft Reconstruction – Activity View
+
+skinparam stereotype {
+  CBackgroundColor<<Producer>> #DFF5E1
+  CBackgroundColor<<Filter>>   #FFEBD6
+  CBackgroundColor<<Analyzer>> #E7E9FF
+}
+
+legend left
+  <<Producer>> produces data products
+  <<Filter>>   gates the path
+  <<Analyzer>> reads/writes analysis outputs
+endlegend
+
 start
 :Read raw::RawDigit;
-:Produce recob::Wire (SignalProcessing);
-:Produce recob::Hit (HitFinding);
-:Produce recob::Cluster (Clustering);
-:PFParticle reconstruction (Pandora);
-:Track/Shower reconstruction;
+:Produce recob::Wire (SignalProcessing) <<Producer>>;
+:Produce recob::Hit (HitFinding) <<Producer>>;
+:Produce recob::Cluster (Clustering) <<Producer>>;
+:PFParticle reconstruction (Pandora) <<Producer>>;
+:Track/Shower reconstruction <<Producer>>;
+:Run MySelection <<Filter>>;
 if (Selection passes?) then (yes)
-  :Write ntuple (Analysis);
+  :Write ntuple (Analysis) <<Analyzer>>;
 else (no)
   :Drop event;
 endif

--- a/analysis.puml
+++ b/analysis.puml
@@ -1,0 +1,34 @@
+@startuml Analysis
+title LArSoft Analysis
+
+skinparam componentStyle rectangle
+skinparam stereotype {
+  CBackgroundColor<<Producer>> #DFF5E1
+  CBackgroundColor<<Filter>>   #FFEBD6
+  CBackgroundColor<<Analyzer>> #E7E9FF
+}
+skinparam rectangle {
+  BorderColor #888
+  RoundCorner 8
+}
+
+legend left
+  <<Filter>>   gates the path
+  <<Analyzer>> reads/writes analysis outputs
+  (dp)         data product type
+endlegend
+
+package "Event (art::Event)" {
+  () "recob::Track/recob::Shower" as TrSh
+  () "anab::Calorimetry" as Calo
+}
+
+component "MySelection"    <<Filter>>   as MySel
+component "AnalysisNtuple" <<Analyzer>> as Ana
+
+TrSh  -up-> MySel : reads
+Calo  -up-> MySel : reads
+MySel -right-> Ana : passes
+
+@enduml
+

--- a/pattern_recognition.puml
+++ b/pattern_recognition.puml
@@ -1,0 +1,37 @@
+@startuml PatternRecognition
+title LArSoft Pattern Recognition
+
+skinparam componentStyle rectangle
+skinparam stereotype {
+  CBackgroundColor<<Producer>> #DFF5E1
+  CBackgroundColor<<Filter>>   #FFEBD6
+  CBackgroundColor<<Analyzer>> #E7E9FF
+}
+skinparam rectangle {
+  BorderColor #888
+  RoundCorner 8
+}
+
+legend left
+  <<Producer>>  makes data products
+  (dp)          data product type
+endlegend
+
+package "Event (art::Event)" {
+  () "recob::Hit"    as Hit
+  () "recob::Cluster" as Cluster
+  () "recob::PFParticle" as PF
+}
+
+component "Clustering" <<Producer>> as Clustering
+component "Pandora"    <<Producer>> as Pandora
+
+Hit       -up-> Clustering : reads
+Clustering -down-> Cluster : produces
+
+Hit     -up-> Pandora : reads
+Cluster -up-> Pandora : reads
+Pandora -down-> PF : produces
+
+@enduml
+

--- a/sequence.puml
+++ b/sequence.puml
@@ -1,5 +1,18 @@
 @startuml LArSoft_Sequence
 autonumber
+
+skinparam stereotype {
+  CBackgroundColor<<Producer>> #DFF5E1
+  CBackgroundColor<<Filter>>   #FFEBD6
+  CBackgroundColor<<Analyzer>> #E7E9FF
+}
+
+legend left
+  <<Producer>>  makes data products
+  <<Filter>>    gates the path
+  <<Analyzer>>  reads/writes outputs
+endlegend
+
 actor "art::Event" as E
 participant "SignalProcessing" as SP <<Producer>>
 participant "HitFinding" as HF <<Producer>>

--- a/signal_processing.puml
+++ b/signal_processing.puml
@@ -1,0 +1,36 @@
+@startuml SignalProcessing
+title LArSoft Signal Processing
+
+skinparam componentStyle rectangle
+skinparam stereotype {
+  CBackgroundColor<<Producer>> #DFF5E1
+  CBackgroundColor<<Filter>>   #FFEBD6
+  CBackgroundColor<<Analyzer>> #E7E9FF
+}
+skinparam rectangle {
+  BorderColor #888
+  RoundCorner 8
+}
+
+legend left
+  <<Producer>>  makes data products
+  (dp)          data product type
+endlegend
+
+package "Event (art::Event)" {
+  () "raw::RawDigit" as RawDigit
+  () "recob::Wire"   as Wire
+  () "recob::Hit"    as Hit
+}
+
+component "SignalProcessing" <<Producer>> as SigProc
+component "HitFinding"      <<Producer>> as HitFinder
+
+RawDigit -up-> SigProc : reads
+SigProc   -down-> Wire : produces
+
+Wire      -up-> HitFinder : reads
+HitFinder -down-> Hit : produces
+
+@enduml
+

--- a/tracking.puml
+++ b/tracking.puml
@@ -1,0 +1,36 @@
+@startuml Tracking
+title LArSoft Tracking
+
+skinparam componentStyle rectangle
+skinparam stereotype {
+  CBackgroundColor<<Producer>> #DFF5E1
+  CBackgroundColor<<Filter>>   #FFEBD6
+  CBackgroundColor<<Analyzer>> #E7E9FF
+}
+skinparam rectangle {
+  BorderColor #888
+  RoundCorner 8
+}
+
+legend left
+  <<Producer>>  makes data products
+  (dp)          data product type
+endlegend
+
+package "Event (art::Event)" {
+  () "recob::PFParticle" as PF
+  () "recob::Track/recob::Shower" as TrSh
+  () "anab::Calorimetry" as Calo
+}
+
+component "Track/Shower" <<Producer>> as TrackShower
+component "Calorimetry"  <<Producer>> as CaloProd
+
+PF         -up-> TrackShower : reads
+TrackShower -down-> TrSh : produces
+
+TrSh     -up-> CaloProd : reads
+CaloProd -down-> Calo : produces
+
+@enduml
+


### PR DESCRIPTION
## Summary
- add stereotype legends to activity and sequence diagrams
- split full workflow into subsystem diagrams for signal processing, pattern recognition, tracking, and analysis

## Testing
- `plantuml -tsvg -o /tmp *.puml`

------
https://chatgpt.com/codex/tasks/task_e_68b8768ba9b8832e8bba2f89c910e79a