### PR TITLE
Remove legend from event selection filter diagram

### DIFF
--- a/docs/event_selection_filter.puml
+++ b/docs/event_selection_filter.puml
@@ -167,14 +167,4 @@ FILTER -down-> TFS : creates\nTTrees
 TFS -down-> TREE : ROOT\noutput file
 ANA ..> TREE : fills\nbranches
 
-legend right
-  1) ResetTTree
-  2) Build PFParticle proxy
-  3) Analyse full event
-  4) Build neutrino slices
-  5) Select + analyse slices
-  6) Fill TTrees
-  7) Optionally filter event
-end legend
-
 @enduml


### PR DESCRIPTION
### Motivation
- Simplify the PlantUML diagram by removing a textual legend that duplicates the sequence steps.
- Reduce visual clutter in the `event_selection_filter` diagram to make the flow clearer.

### Description
- Deleted the `legend right` … `end legend` block from `docs/event_selection_filter.puml`.
- Left the rest of the diagram and the terminating `@enduml` intact with no other modifications.

### Testing
- No automated tests were run because this is a documentation/diagram-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696695c90764832eb4c1a89b9d217f6d)